### PR TITLE
Add multiply and consolidate input handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -6,14 +6,29 @@ function subtract(a, b) {
   return a - b;
 }
 
-document.getElementById('btn-add').addEventListener('click', () => {
-  const a = Number(document.getElementById('a').value);
-  const b = Number(document.getElementById('b').value);
-  document.getElementById('result').textContent = add(a, b);
-});
+function multiply(a, b) {
+  return a * b;
+}
 
-document.getElementById('btn-subtract').addEventListener('click', () => {
-  const a = Number(document.getElementById('a').value);
-  const b = Number(document.getElementById('b').value);
-  document.getElementById('result').textContent = subtract(a, b);
-});
+function calculateAndDisplay(fn) {
+  const rawA = document.getElementById('a').value;
+  const rawB = document.getElementById('b').value;
+
+  if (rawA === '' || rawB === '') {
+    document.getElementById('result').textContent = 'Please fill both inputs';
+    return;
+  }
+
+  const a = Number(rawA);
+  const b = Number(rawB);
+  document.getElementById('result').textContent = fn(a, b);
+}
+
+document.getElementById('btn-add')
+  .addEventListener('click', () => calculateAndDisplay(add));
+
+document.getElementById('btn-subtract')
+  .addEventListener('click', () => calculateAndDisplay(subtract));
+
+document.getElementById('btn-multiply')
+  .addEventListener('click', () => calculateAndDisplay(multiply));

--- a/tests.html
+++ b/tests.html
@@ -23,6 +23,21 @@
       assert.equal(subtract(5, 3), 2, '5 - 3 = 2');
       assert.equal(subtract(0, 4), -4, '0 - 4 = -4');
     });
+
+    QUnit.test('multiply()', assert => {
+      assert.equal(multiply(2, 3), 6, '2 × 3 = 6');
+    });
+
+    QUnit.test('subtract with empty inputs', assert => {
+      document.getElementById('a').value = '';
+      document.getElementById('b').value = '';
+      document.getElementById('btn-subtract').click();
+      assert.equal(
+        document.getElementById('result').textContent,
+        'Please fill both inputs',
+        'Shows warning if inputs are empty'
+      );
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
Introduce multiply(a, b) and refactor click handlers into calculateAndDisplay(fn) to remove duplicated code and centralize input parsing/validation. The handler now shows a friendly message when either input is empty. Wire up btn-multiply and update tests to include multiply() and a UI test that verifies the empty-input warning.